### PR TITLE
Upgrade influxdb grafana

### DIFF
--- a/bin/grafana/Dockerfile
+++ b/bin/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.0.4
+FROM grafana/grafana:5.2.1
 MAINTAINER martinc@ucar.edu
 
 RUN apt-get update

--- a/bin/grafana/Dockerfile
+++ b/bin/grafana/Dockerfile
@@ -1,5 +1,6 @@
 FROM grafana/grafana:5.2.1
 MAINTAINER martinc@ucar.edu
+USER root
 
 RUN apt-get update
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
   # InfluxData influxdb time-series database
   influxdb:
     container_name: chords_influxdb
-    image: influxdb:1.4
+    image: influxdb:1.6
     volumes:
       - influxdb-data:/var/lib/influxdb
       - influxdb-log:/var/log/influxdb
@@ -160,7 +160,7 @@ services:
   # Grafana graphing server. It draws data from influxdb.
   grafana:
     container_name: chords_grafana
-    image: ncareol/grafana:5.0.4
+    image: ncareol/grafana:5.2.1
     # Note: GF_ variables are used by grafana, meaning that
     # you should not create your own variables beginning with GF_.
     environment:
@@ -185,6 +185,7 @@ services:
         max-file: "5"
     ports:
       - ${GRAFANA_HTTP_PORT}:${GRAFANA_HTTP_PORT}
+    user: "104"
     links:
       - influxdb
 


### PR DESCRIPTION
Docker image ncareol/chords:upgrade_influxdb_grafana pushed to docker hub, and it is successfully running on localhost, linode and wx.