### PR TITLE
mysql-client in Dockerfile changed to default-mysql-client as older l…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="martinc@ucar.edu"
 RUN apt-get update && apt-get install -y \
   build-essential \
   nodejs \
-  mysql-client \
+  default-mysql-client \
   default-libmysqlclient-dev \
   dos2unix \
   cron \


### PR DESCRIPTION
 mysql-client in Dockerfile changed to default-mysql-client as older library if no longer avaiable.