### PR TITLE
Highcharts multivariable fix

### DIFF
--- a/app/views/instruments/_multivariable_graph.html.haml
+++ b/app/views/instruments/_multivariable_graph.html.haml
@@ -7,8 +7,6 @@
   function toggle_run_state(id, refresh_ms) {
 
 
-    // console.log($('#toggle_live_updating').attr('src'));
-
     if (live_updating_run_status == false) {
       // set the run status to true
       eval("live_updating_run_status = true;");
@@ -31,15 +29,12 @@
       stopLiveUpdate();
     }
 
-
-    // console.log(live_updating_run_status);
   }
 
   function startLiveUpdate() {
     var refresh_seconds = parseInt($('#refresh_seconds').val());
     if (refresh_seconds) {
       live_refresh_msecs = refresh_seconds * 1000;
-      console.log(live_refresh_msecs);
     }
     
     live_updating_interval = setInterval(updateHighchartsGraph, live_refresh_msecs);

--- a/app/views/instruments/_multivariable_graph_chart.html.haml
+++ b/app/views/instruments/_multivariable_graph_chart.html.haml
@@ -13,6 +13,19 @@
   ////////// Initialization of Variables ///////////
   //////////////////////////////////////////////////
 
+  // Increase the size of the Highcharts color pallete
+  var new_colors = [
+    '#FF0000',  '#00FF00',  '#0000FF',  '#FFFF00',  '#FF00FF',  
+    '#00FFFF',  '#800000',  '#008000',  '#000080',  '#808000',  
+    '#800080',  '#008080',  '#FFA500',  '#FF69B4',  '#DC143C',  
+    '#FF6347',  '#00FF7F',  '#8B008B',  '#4B0082',  '#FFD700',  
+    '#FF8C00',  '#A0522D',  '#9400D3',  '#00CED1',  '#FF1493',  
+    '#00FA9A',  '#FF00FF',  '#ADFF2F',  '#FF4500',  '#8FBC8F']
+
+  Highcharts.setOptions({
+        colors: Highcharts.getOptions().colors.concat(new_colors)
+  });
+
   // intialize series array that contain hashes corresponding to each variable
   var live_series = [];
 
@@ -41,16 +54,24 @@
   var variable_index = 0;
   variables.forEach (function(v) {
 
+
+    // Get the color to use for the variable
+    // Make sure that the index of the color exists in the Highcharts configuration, 
+    // and if we've run out of colors, loop them 
+    var highcharts_color_index = variable_index % (Highcharts.getOptions().colors.length) ;
+    
+    var highcharts_color = Highcharts.getOptions().colors[highcharts_color_index].toString();
+
     var y_axis_js_part = '';
     y_axis_js_part += '{\n';
     y_axis_js_part += '  "labels": {\n';
     y_axis_js_part += '      "format": "{value} ' + v.units + '"' +  ',\n';
-    y_axis_js_part += '       "style": { "color": "' + Highcharts.getOptions().colors[variable_index].toString() + '" }\n';
+    y_axis_js_part += '       "style": { "color": "' + highcharts_color + '" }\n';
     y_axis_js_part += '  },\n';
 
     y_axis_js_part += '  "title": {\n ';
     y_axis_js_part += '   "text": "' + v.name + ' (' + v.units + ')",\n';
-    y_axis_js_part += '   "style": { "color": "' + Highcharts.getOptions().colors[variable_index].toString() + '" }\n';
+    y_axis_js_part += '   "style": { "color": "' + highcharts_color + '" }\n';
     y_axis_js_part += '  },\n';
 
     y_axis_js_part += '  "opposite": false,\n';
@@ -231,6 +252,7 @@
   ////////////////////////////////////////
 
   $(document).ready(function () {
+
     // adjust the global timezone offset
     Highcharts.setOptions({
       global: {

--- a/app/views/instruments/_multivariable_graph_chart.html.haml
+++ b/app/views/instruments/_multivariable_graph_chart.html.haml
@@ -98,7 +98,6 @@
     var request_string = '/instruments/#{@instrument.id}/live?var=' + currVar + '&start=' + starttime + '&end=' + endtime;
 
     $.getJSON(request_string, function (data) {
-      // console.log(data);
       addNewVarData(data, currVar);
     });
   }
@@ -133,8 +132,6 @@
     var multivariable_points = data["multivariable_points"];
     var multivariable_names = data["multivariable_names"];
     var live_refresh_msecs = data["refresh_msecs"];
-
-    // console.log(live_refresh_msecs);
 
     // loop through all variables
     for (i = 0; i < multivariable_names.length; i++) {
@@ -313,9 +310,6 @@
 
     function toggle_run_state(id, refresh_ms) {
 
-
-      // console.log($('#toggle_live_updating').attr('src'));
-
       if (live_updating_run_status == false) {
         // set the run status to true
         eval("live_updating_run_status = true;");
@@ -336,8 +330,6 @@
         $('#toggle_live_updating').attr('src', chords.toggleOffSwitch);
       }
 
-
-      // console.log(live_updating_run_status);
     }
 
 


### PR DESCRIPTION
Highcharts fixe so that having more than 10 variables on an instrument doesn't break the chart. 

There are only 10 colors defined by default in Highcharts. 30 more were added, and looping was implemented in case all defined colors are used. (More than 40 variables per instrument.