### PR TITLE
Fix for Dockerfile smell DL3006

### DIFF
--- a/bin/certbot/Dockerfile
+++ b/bin/certbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM certbot/certbot 
+FROM certbot/certbot:amd64-v2.5.0 
 
 # Install Docker on the container itself, so that this 
 # container can can ask docker to restart nginx after cert renewal.


### PR DESCRIPTION
Hi!
The Dockerfile placed at "bin/certbot/Dockerfile" contains the best practice violation [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3006 occurs when the image tag for the base image is missing.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the given base image. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag, used by default when pulling the image from DockerHub if a specific image tag is missing.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance